### PR TITLE
Refactor grammar to reduce conflicts

### DIFF
--- a/src/erlex_parser.yrl
+++ b/src/erlex_parser.yrl
@@ -1,7 +1,7 @@
 Nonterminals
 
 assignment
-atom
+atom atom_simple
 binary binary_items binary_part
 byte
 byte_list byte_items
@@ -18,7 +18,8 @@ rest
 tuple
 type
 value_items
-values value.
+values value
+base_value.
 
 Terminals
 
@@ -44,6 +45,16 @@ int
 
 Rootsymbol document.
 
+Right 100 '|'.
+Right 90 '='.
+Nonassoc 80 '::'.
+Nonassoc 70 ':'.
+Nonassoc 60 when.
+Left 50 atom_simple integer list.
+Right 40 ','.
+Right 30 '>' '#'.
+Nonassoc 20 '(' '['.
+
 document -> values : '$1'.
 
 values -> value : ['$1'].
@@ -51,20 +62,22 @@ values -> value values : ['$1'] ++ '$2'.
 
 value -> '\'' value '\'' : '$2'.
 value -> assignment : '$1'.
-value -> atom : {atom, '$1'}.
-value -> binary : '$1'.
-value -> byte_list : '$1'.
-value -> contract : '$1'.
-value -> function : '$1'.
-value -> integer : '$1'.
-value -> list : '$1'.
-value -> map : '$1'.
-value -> pattern : '$1'.
 value -> pipe_list : '$1'.
-value -> range : '$1'.
-value -> rest : '$1'.
-value -> tuple : '$1'.
-value -> type : '$1'.
+value -> base_value : '$1'.
+
+base_value -> atom : {atom, '$1'}.
+base_value -> binary : '$1'.
+base_value -> byte_list : '$1'.
+base_value -> contract : '$1'.
+base_value -> function : '$1'.
+base_value -> integer : '$1'.
+base_value -> list : '$1'.
+base_value -> map : '$1'.
+base_value -> range : '$1'.
+base_value -> rest : '$1'.
+base_value -> tuple : '$1'.
+base_value -> type : '$1'.
+base_value -> pattern : '$1'.
 
 binary -> '<' '<' '>' '>' : {binary, []}.
 binary -> '<' '<' binary_items '>' '>' : {binary, '$3'}.
@@ -112,12 +125,13 @@ range -> integer '..' integer : {range, '$1', '$3'}.
 
 rest -> '...' : {rest}.
 
-atom -> atom_full : unwrap('$1').
-atom -> atom_part : [unwrap('$1')].
-atom -> '_' : ['_'].
-atom -> atom integer : '$1' ++ ['$2'].
-atom -> atom atom : '$1' ++ '$2'.
+atom_simple -> atom_full : unwrap('$1').
+atom_simple -> atom_part : [unwrap('$1')].
+atom_simple -> '_' : ['_'].
 
+atom -> atom_simple : '$1'.
+atom -> atom atom_simple : '$1' ++ '$2'.
+atom -> atom integer : '$1' ++ ['$2'].
 type -> atom ':' type : {type, {atom, '$1'}, '$3'}.
 type -> atom '::' value : {named_type, {atom, '$1'}, '$3'}.
 type -> atom list : {type_list, '$1', '$2'}.


### PR DESCRIPTION
### Related Issue:
 Compiling the project emmited many yecc warnings #2
Warning: conflicts: 27 shift/reduce, 0 reduce/reduce

### What does this PR do? 

1) Factor `value` through `base_value` (alias-only grouping).
   In the current grammar, `value` mixes many alternatives (atoms, lists, maps, binaries, types, patterns, etc.) together with constructs that later compete for lookahead (e.g., `pipe_list`, `assignment`). Introducing:
   - `value -> ... | assignment | pipe_list | base_value`
   - `base_value -> atom | binary | byte_list | contract | function | integer | list | map | range | rest | tuple | type | pattern`
   
   separates the “plain” value forms from the higher-precedence constructs. This removes several conflicts where the parser previously had to choose between **reducing to `value`** and **shifting** to continue a larger construct (e.g., states with `value/value_items`, `|`, `=`, `when`).  
   Semantically, `value -> base_value : '$1'` just forwards the synthesized value.

2) Introduce `atom_simple` for the base cases; keep `atom` growth explicit.
   A major source of warnings was `atom` doubling as both a base and a recursive extender. I split:
   - Bases into `atom_simple` (`atom_full`, `atom_part`, `'_'`).
   - Growth remains via the same two rules: `atom -> atom atom_simple` and `atom -> atom integer`.

   This makes the extend atom path unambiguous (shift is now intended by construction).

3) Add explicit precedence/associativity to encode intended policy.
```
Right 100 '|'.
Right 90 '='.
Nonassoc 80 '::'.
Nonassoc 70 ':'.
Nonassoc 60 when.
Left 50 atom_simple integer list.
Right 40 ','.
Right 30 '>' '#'.
Nonassoc 20 '(' '['.
```

### Correctness
  - `value → base_value` is an alias refactor: every old derivation `value ⇒ X` becomes `value ⇒ base_value ⇒ X` and vice versa.
  - `atom` is preserved by splitting out the bases (`atom_full | atom_part | '_'`) into `atom_simple`, and keeping the same growth rules:  
    `atom → atom atom_simple` and `atom → atom integer`.  
    By induction on components, accepted strings are unchanged.
  - Precedence/associativity do not add/remove productions; they only select a canonical parse.
  
### How can this be manually tested? 
Run mix compile and it should compile without warnings.